### PR TITLE
Update /games endpoint to /applications in activity command

### DIFF
--- a/src/commands/info/activity.js
+++ b/src/commands/info/activity.js
@@ -142,8 +142,6 @@ module.exports = class ActivityCommand extends Command {
           : activity.assets.largeText, true)
         : null;
 
-      activity.applicationID ? embed.addField('Application ID', activity.applicationID, true) : null;
-
       deleteCommandMessages(msg, this.client);
       stopTyping(msg);
 

--- a/src/commands/info/activity.js
+++ b/src/commands/info/activity.js
@@ -57,7 +57,7 @@ module.exports = class ActivityCommand extends Command {
       ava = member.user.displayAvatarURL(),
       embed = new MessageEmbed(),
       ext = this.fetchExt(ava),
-      gameList = await request.get('https://canary.discordapp.com/api/v6/games'),
+      gameList = await request.get('https://canary.discordapp.com/api/v6/applications'),
       spotifyApi = new Spotify({
         clientId: process.env.spotifyid,
         clientSecret: process.env.spotifysecret


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This change makes it so ribbon now uses the `/applications` endpoint instead of `/games` since I noticed discord removed `/games` from their web client and made it `/applications`

This means activity will still work if for some reason they decide to remove `/games` from their web api.

**Semantic versioning classification:**  
- [ ] This PR changes the adds extra commands to the bot
- [x] This PR improves existing commands
- [ ] This PR **only** includes non-code changes, like changes to documentation, README, or images to memes / reactions